### PR TITLE
Kasowanie zbędnych containerów i poprawki dla row

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,14 +59,14 @@
 	</div>
 </div>
 
-
-<div class="divider" id="section1"></div>
-
-<div class="col-sm-6 col-sm-offset-3 text-center font">
-	<h2 style="padding:20px;background-color:rgba(83,44,85,1); color:white;">O konferencji</h2>
-</div>
 <div class="container">
-	<br><br><br><br><br><br>
+	<div class="divider" id="section1"></div>
+	<div class="row">
+		<div class="col-sm-6 col-sm-offset-3 text-center font">
+			<h2 style="padding:20px;background-color:rgba(83,44,85,1); color:white;">O konferencji</h2>
+		</div>
+	</div>
+
 	<p class="lead text-center font"> 
 		<span class="tytul">II Ogólnopolska Konferencja Interdyscyplinarna pt. &#8222;Współczesne zastosowania informatyki&#8221; <br>20 maja 2016, Siedlce </span>
 	</p>
@@ -80,9 +80,7 @@
 		<br />Relacja z <a href="http://www.wns.uph.edu.pl/strona-glowna/aktualnosci/478-ogolnopolska-konferencja-interdyscyplinarna-pt-wspolczesne-zastosowania-informatyki"> poprzedniej edycji</a>
 		<br /><br />
 	</p> 
-</div>
 
-<div class="container">
 	<div class="lead text-center font">
 		<a class="btn" style="padding:20px;background-color:rgba(83,44,85,1); color:white;" data-toggle="collapse" href="#collapseRada" aria-expanded="false" aria-controls="collapseRada">
 			Rada Naukowa &nbsp; <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span> 
@@ -123,14 +121,13 @@
 			Wykorzystanie technologii informacyjnych w edukacji<br><br>
 		</div>
 	</div>
-</div>
+	<div class="divider" id="section2"></div>
+	<div class="row">
+		<div class="col-sm-6 col-sm-offset-3 text-center font">
+			<h2 style="padding:20px;background-color:rgba(83,44,85,1); color:white;">Terminy</h2>
+		</div>
+	</div>
 
-<div class="divider" id="section2"></div>
-<div class="col-sm-6 col-sm-offset-3 text-center font">
-	<h2 style="padding:20px;background-color:rgba(83,44,85,1); color:white;">Terminy</h2>
-</div>
-<br><br><br><br><br><br>
-<div class="container">
 	<div class="lead text-center font">
 		<p>
 			Termin nadsyłania zgłoszeń (i abstraktów): do 11 maja 2016.<br>
@@ -149,69 +146,60 @@
 			Publikacja będzie wydana do września 2016 w formie elektronicznej i zostanie nadany jej numer ISBN.<br /><br />
 		</div>
 	</div>
-</div>
 
-<div class="divider" id="section3"></div>
+	<div class="divider" id="section3"></div>
 
-<div class="col-sm-6 col-sm-offset-3 text-center font">
-	<h2 style="padding:20px;background-color:rgba(83,44,85,1); color:white;">Zgłoszenia</h2>
-</div>
-<br><br><br><br><br><br>
-<div class="container">
-	<div class="col-sm-10 col-sm-offset-1">
-		<img src="images/separator-down.png" alt="separator">
-		<div class="google-form text-center font">
-			<p>Formularz zgłoszeniowy</p>
-			<a href="https://docs.google.com/forms/d/1fL-Lrc_4nxHC1sDC_fbTB34RQp2Hj9ubGNU1v55UWwo/viewform">Zarejestruj się!</a>
-			<br /><small>(termin zgłoszeń do 11 maja 2016)</small>
+	<div class="row">
+		<div class="col-sm-6 col-sm-offset-3 text-center font">
+			<h2 style="padding:20px;background-color:rgba(83,44,85,1); color:white;">Zgłoszenia</h2>
 		</div>
-		<img src="images/separator-up.png" alt="separator">
-		<div class="lead text-center font">
-			<br>Konferencja będzie podzielona na dwie części: panel ekspercki oraz panel studencki. <br>W trakcie obrad przewidziane są przerwy kawowe. <br>Czas przeznaczony na wystąpienie w panelu studenckim: 15 minut.
+	</div>
+	<div class="row">
+		<div class="col-sm-10 col-sm-offset-1">
+			<img src="images/separator-down.png" alt="separator">
+			<div class="google-form text-center font">
+				<p>Formularz zgłoszeniowy</p>
+				<a href="https://docs.google.com/forms/d/1fL-Lrc_4nxHC1sDC_fbTB34RQp2Hj9ubGNU1v55UWwo/viewform">Zarejestruj się!</a>
+				<br /><small>(termin zgłoszeń do 11 maja 2016)</small>
+			</div>
+			<img src="images/separator-up.png" alt="separator">
+			<div class="lead text-center font">
+				<br>Konferencja będzie podzielona na dwie części: panel ekspercki oraz panel studencki. <br>W trakcie obrad przewidziane są przerwy kawowe. <br>Czas przeznaczony na wystąpienie w panelu studenckim: 15 minut.
+			</div>
+			<!--<br>
+			<br>
+			<center>
+				<div class="fb-post text-center font" data-href="https://www.facebook.com/knigenbit/posts/666842863421233?hc_location=ufi" data-width="500"><div class="fb-xfbml-parse-ignore"><blockquote cite="https://www.facebook.com/knigenbit/posts/666842863421233">Posted by <a href="https://www.facebook.com/knigenbit">KNI Genbit</a> on <a href="https://www.facebook.com/knigenbit/posts/666842863421233">Thursday, 16 April 2015</a></blockquote></div></div>
+			</center>-->
 		</div>
-		<!--<br>
-		<br>
-		<center>
-			<div class="fb-post text-center font" data-href="https://www.facebook.com/knigenbit/posts/666842863421233?hc_location=ufi" data-width="500"><div class="fb-xfbml-parse-ignore"><blockquote cite="https://www.facebook.com/knigenbit/posts/666842863421233">Posted by <a href="https://www.facebook.com/knigenbit">KNI Genbit</a> on <a href="https://www.facebook.com/knigenbit/posts/666842863421233">Thursday, 16 April 2015</a></blockquote></div></div>
-		</center>-->
-	</div>  
-</div>
-
-
-<div class="divider" id="section4"></div>
-
-
-<div class="col-sm-6 col-sm-offset-3 text-center font"><h2 style="padding:20px;background-color:rgba(83,44,85,1); color:white;">Agenda</h2></div>
-<br><br><br><br><br><br>
-<div class="container">
+	</div>
+	<div class="divider" id="section4"></div>
+	<div class="row">
+		<div class="col-sm-6 col-sm-offset-3 text-center font">
+			<h2 style="padding:20px;background-color:rgba(83,44,85,1); color:white;">Agenda</h2>
+		</div>
+	</div>
 	<div class="lead text-center font">
 		<p>Agenda ukaże się po 13 maja 2016.</p>
 	</div>
-</div>
-
-<div class="divider" id="section5"></div>
-			
-
-<div class="col-sm-6 col-sm-offset-3 text-center font">
-	<h2 style="padding:20px;background-color:rgba(83,44,85,1); color:white;">Miejsce</h2>
-</div>
-<br><br><br><br><br><br>
-	
-<div class="container">
+	<div class="divider" id="section5"></div>
+	<div class="row">
+		<div class="col-sm-6 col-sm-offset-3 text-center font">
+			<h2 style="padding:20px;background-color:rgba(83,44,85,1); color:white;">Miejsce</h2>
+		</div>
+	</div>
 	<div class="lead text-center font">
 		<center>
 			<div id="map-canvas"></div>
 		</center>
 	</div>
 	<center>ul. 3 Maja 54, Siedlce (Wydział Nauk Ścisłych Uniwersytetu Przyrodniczo-Humanistycznego w Siedlcach)</center>
+	<br><br><br> 
 </div>
-	
 
-
-<br><br><br> 
 <div id="footer">
 	<div class="container">
-
+	
 		<div class="address">
 			<address class="text-muted text-right">
 				Adres korespondencyjny: <br>
@@ -225,17 +213,15 @@
 				<strong class="address">E-mail</strong><br>
 				<a href="mailto:genbit@uph.edu.pl">genbit@uph.edu.pl</a>   
 			</address>
-
+	
 		</div>
-
+	
 		<ul class="list-inline center-block">
 			<p class="text-muted" style="width: 50%">Organizatorzy: <a href="https://www.facebook.com/knigenbit">Koło Naukowe Informatyków Genbit</a> <a href="http://www.uph.edu.pl/">Uniwersytetu Przyrodniczo-Humanistycznego w Siedlcach</a>.</p>
 			<br /><!--<li><a href="https://www.facebook.com/events/1607860262767765/"><img src="images/fb_active.png"width="50" height="50"></a></li>-->
 		</ul>
 		<p class="text-muted copy" >Copyright <a href="https://www.facebook.com/knigenbit">KNI Genbit</a> ©2016, template by ACME, Inc.</p>
 	</div>
-
-
 </div>
 
 <ul class="nav pull-right scroll-top">


### PR DESCRIPTION
Szanowni,

Nie ma elementów, które muszą dotykać krawędzi ekranu, a więc na stronie może być dużo mniej containerów.
Każda kolumna (`.col-*`) powinna być `.row`, aby zadziałał clearfix i nie nachodził tekst.  Z tego tez powodu zbyteczna jest brzydki hack z wielokrotnymi przejściami do nowej linii. 

@mkczyk zmerguj, chyba, że masz pytania. 

Pozdrawiam

PS. divider jako element pusty też powinien  zostać skasowany. Zamiast tego lepiej stworzyć element `<div class="section" id="section_about"></div>` i ustawić w nim padding/margin.
PS2. Na pewno potrzeba tyle przejść do nowych linii? Może coś jest listą bez kropek `<ul class="list-unstyled"><li>...</li></ul>`, albo akapitem `<p></p>`. W praktyce to bardzo rzadko potrzebujesz tak brutalnego przejścia do nowej linii. 
